### PR TITLE
✨ Feature: Zou het mogelijk zijn ook open bestellingen, dus d

### DIFF
--- a/features/feature-46161f72.md
+++ b/features/feature-46161f72.md
@@ -1,0 +1,7 @@
+**Type:** Feature-aanvraag
+**Reporter:** Open bestellingen
+**Datum:** 2025-06-04 09:48
+
+**Beschrijving:**
+
+Zou het mogelijk zijn ook open bestellingen, dus dingen die we nog verwachten, toe te voegen? Als we daar dan ook de leverdatum kunnen toevoegen kan een PL/verkoper makkelijk zien wanneer hij zijn goederen kan verwachten.


### PR DESCRIPTION
Automatisch gegenereerde feature-aanvraag door Open bestellingen op 2025-06-04 09:48:

Zou het mogelijk zijn ook open bestellingen, dus dingen die we nog verwachten, toe te voegen? Als we daar dan ook de leverdatum kunnen toevoegen kan een PL/verkoper makkelijk zien wanneer hij zijn goederen kan verwachten.