### PR TITLE
✨ Feature: Tab project, na ingeven projectnummer, opent een n

### DIFF
--- a/features/feature-8a8c3bf7.md
+++ b/features/feature-8a8c3bf7.md
@@ -1,0 +1,10 @@
+**Type:** Feature-aanvraag
+**Reporter:** Dries
+**Datum:** 2025-06-19 08:13
+
+**Beschrijving:**
+
+Tab project, na ingeven projectnummer, opent een nieuw kader. 
+Indien mogelijk graag een knopje erbij (naast kruisje) om full screen (maximaliseren) te gaan.
+
+Thx.


### PR DESCRIPTION
Automatisch gegenereerde feature-aanvraag door Dries op 2025-06-19 08:13:

Tab project, na ingeven projectnummer, opent een nieuw kader. 
Indien mogelijk graag een knopje erbij (naast kruisje) om full screen (maximaliseren) te gaan.

Thx.