### PR TITLE
✨ Feature: Zou je bv ook de verkooporders die ingeboekt zijn 

### DIFF
--- a/features/feature-db576790.md
+++ b/features/feature-db576790.md
@@ -1,0 +1,7 @@
+**Type:** Feature-aanvraag
+**Reporter:** Stijn
+**Datum:** 2025-06-21 16:08
+
+**Beschrijving:**
+
+Zou je bv ook de verkooporders die ingeboekt zijn kunnen toevoegen? Dit zou makkelijk kunnen zijn voor de orderadmins van Lodax.


### PR DESCRIPTION
Automatisch gegenereerde feature-aanvraag door Stijn op 2025-06-21 16:08:

Zou je bv ook de verkooporders die ingeboekt zijn kunnen toevoegen? Dit zou makkelijk kunnen zijn voor de orderadmins van Lodax.