### PR TITLE
✨ Feature: We zijn volop bezig met de verpakkingshoeveelheden

### DIFF
--- a/features/feature-542e306b.md
+++ b/features/feature-542e306b.md
@@ -1,0 +1,13 @@
+**Type:** Feature-aanvraag
+**Reporter:** Stijn
+**Datum:** 2025-12-08 09:26
+
+**Beschrijving:**
+
+We zijn volop bezig met de verpakkingshoeveelheden in SAP te stoppen. Collega's hebben dit in de artikelomschrijving gezet, is niet zo netje.
+Kan je dit ergens zichtbaar maken in een eerste scherm?
+
+Bij installations hebben ze ook een Q uitgevonden om aan te tonen dat iets standaard is, da's een beetje raar want dat kan veranderen en wordt niet onderhouden. Zou bv een kleurtje kunnen voor de artikels die we standaard op stock houden (dit is bv een min niveau verschillende van 0). Op die manier duwen we iedereen iets meer naar het gebruik van artikelen die roteren en zou de stock moeten zakken & leverbetrouwbaarheid groeien.
+Blijkt bv bij Proatwork dat we heel wat tussenmaten van bouten bestellen, wat me eigenlijk onnozel lijkt.
+
+Dank je!


### PR DESCRIPTION
Automatisch gegenereerde feature-aanvraag door Stijn op 2025-12-08 09:26:

We zijn volop bezig met de verpakkingshoeveelheden in SAP te stoppen. Collega's hebben dit in de artikelomschrijving gezet, is niet zo netje.
Kan je dit ergens zichtbaar maken in een eerste scherm?

Bij installations hebben ze ook een Q uitgevonden om aan te tonen dat iets standaard is, da's een beetje raar want dat kan veranderen en wordt niet onderhouden. Zou bv een kleurtje kunnen voor de artikels die we standaard op stock houden (dit is bv een min niveau verschillende van 0). Op die manier duwen we iedereen iets meer naar het gebruik van artikelen die roteren en zou de stock moeten zakken & leverbetrouwbaarheid groeien.
Blijkt bv bij Proatwork dat we heel wat tussenmaten van bouten bestellen, wat me eigenlijk onnozel lijkt.

Dank je!