### PR TITLE
✨ Feature: Peppol invoice status: opvangen errors bv. verkeer

### DIFF
--- a/features/feature-48e3ca0e.md
+++ b/features/feature-48e3ca0e.md
@@ -1,0 +1,7 @@
+**Type:** Feature-aanvraag
+**Reporter:** Bart Bossut
+**Datum:** 2026-02-05 13:28
+
+**Beschrijving:**
+
+Peppol invoice status: opvangen errors bv. verkeerde of onbekend nummer, error response opvangen


### PR DESCRIPTION
Automatisch gegenereerde feature-aanvraag door Bart Bossut op 2026-02-05 13:28:

Peppol invoice status: opvangen errors bv. verkeerde of onbekend nummer, error response opvangen