### PR TITLE
✨ Feature: Bij download van de uurregistratie, vroegr ging hi

### DIFF
--- a/features/feature-992c5f41.md
+++ b/features/feature-992c5f41.md
@@ -1,0 +1,7 @@
+**Type:** Feature-aanvraag
+**Reporter:** Wolf
+**Datum:** 2026-02-09 09:30
+
+**Beschrijving:**
+
+Bij download van de uurregistratie, vroegr ging hij automtisch open. Nu moet je de file gaan zoeken in C:/temp .


### PR DESCRIPTION
Automatisch gegenereerde feature-aanvraag door Wolf op 2026-02-09 09:30:

Bij download van de uurregistratie, vroegr ging hij automtisch open. Nu moet je de file gaan zoeken in C:/temp .