### PR TITLE
✨ Feature: Vanuit het LODAX team kwam er de vraag om te kunne

### DIFF
--- a/features/feature-9409fb99.md
+++ b/features/feature-9409fb99.md
@@ -1,0 +1,8 @@
+**Type:** Feature-aanvraag
+**Reporter:** Conrad Bonné
+**Datum:** 2026-06-15 14:22
+
+**Beschrijving:**
+
+Vanuit het LODAX team kwam er de vraag om te kunnen zoeken op artikel groepen. Zo zou het typen van 151. en dan alle stempelplaten helpen om de klanten snel van een antwoord te voorzien. In 1 oogopslag kan dan gezien worden welk alternatief artikel eventueel wel nog voldoende voorraad heeft. 
+Het zou dan ook handig zijn dat er kan gedubbelklikt worden op een kolomhoofd (artikel nummer, beschrijving, stock, ...) om ze zo te sorteren op nummer.


### PR DESCRIPTION
Automatisch gegenereerde feature-aanvraag door Conrad Bonné op 2026-06-15 14:22:

Vanuit het LODAX team kwam er de vraag om te kunnen zoeken op artikel groepen. Zo zou het typen van 151. en dan alle stempelplaten helpen om de klanten snel van een antwoord te voorzien. In 1 oogopslag kan dan gezien worden welk alternatief artikel eventueel wel nog voldoende voorraad heeft. 
Het zou dan ook handig zijn dat er kan gedubbelklikt worden op een kolomhoofd (artikel nummer, beschrijving, stock, ...) om ze zo te sorteren op nummer.