### PR TITLE
✨ Feature: Onbekende Peppol-foutcode (nog niet in pep_errors.

### DIFF
--- a/features/feature-668136c8.md
+++ b/features/feature-668136c8.md
@@ -1,0 +1,13 @@
+**Type:** Feature-aanvraag
+**Reporter:** TEST Bart
+**Datum:** 2026-08-06 12:20
+
+**Beschrijving:**
+
+Onbekende Peppol-foutcode (nog niet in pep_errors.json).
+
+Factuurnummer: 260700195
+
+Ruwe boodschap zoals ontvangen van de API:
+Error 15001: Error from response (BadRequest): 
+{"errors":[{"Code":"This_0_WasAlreadySentLessThen_1_MinutesAgoTo_2_OrIsStillInTheQueue","Description":"Deze <a href='/Order/Income/Invoice/133500754/EditOrder' target='_blank'> factuur (Nr 260700195)</a> w


### PR DESCRIPTION
Automatisch gegenereerde feature-aanvraag door TEST Bart op 2026-08-06 12:20:

Onbekende Peppol-foutcode (nog niet in pep_errors.json).

Factuurnummer: 260700195

Ruwe boodschap zoals ontvangen van de API:
Error 15001: Error from response (BadRequest): 
{"errors":[{"Code":"This_0_WasAlreadySentLessThen_1_MinutesAgoTo_2_OrIsStillInTheQueue","Description":"Deze <a href='/Order/Income/Invoice/133500754/EditOrder' target='_blank'> factuur (Nr 260700195)</a> w