### PR TITLE
✨ Feature: Onbekende Peppol-foutcode (nog niet in pep_errors.

### DIFF
--- a/features/feature-e48f483a.md
+++ b/features/feature-e48f483a.md
@@ -1,0 +1,13 @@
+**Type:** Feature-aanvraag
+**Reporter:** test 2 barre
+**Datum:** 2026-08-06 12:25
+
+**Beschrijving:**
+
+Onbekende Peppol-foutcode (nog niet in pep_errors.json).
+
+Factuurnummer: 260700195
+
+Ruwe boodschap zoals ontvangen van de API:
+Error 15001: Error from response (BadRequest): 
+{"errors":[{"Code":"This_0_WasAlreadySentLessThen_1_MinutesAgoTo_2_OrIsStillInTheQueue","Description":"Deze <a href='/Order/Income/Invoice/133500754/EditOrder' target='_blank'> factuur (Nr 260700195)</a> w


### PR DESCRIPTION
Automatisch gegenereerde feature-aanvraag door test 2 barre op 2026-08-06 12:25:

Onbekende Peppol-foutcode (nog niet in pep_errors.json).

Factuurnummer: 260700195

Ruwe boodschap zoals ontvangen van de API:
Error 15001: Error from response (BadRequest): 
{"errors":[{"Code":"This_0_WasAlreadySentLessThen_1_MinutesAgoTo_2_OrIsStillInTheQueue","Description":"Deze <a href='/Order/Income/Invoice/133500754/EditOrder' target='_blank'> factuur (Nr 260700195)</a> w