### PR TITLE
✨ Feature: Onbekende Peppol-foutcode (nog niet in pep_errors.

### DIFF
--- a/features/feature-46b4864c.md
+++ b/features/feature-46b4864c.md
@@ -1,0 +1,12 @@
+**Type:** Feature-aanvraag
+**Reporter:** test 4
+**Datum:** 2026-08-06 13:23
+
+**Beschrijving:**
+
+Onbekende Peppol-foutcode (nog niet in pep_errors.json).
+
+Factuurnummer: 260700190
+
+Ruwe boodschap zoals ontvangen van de API:
+Task completed


### PR DESCRIPTION
Automatisch gegenereerde feature-aanvraag door test 4 op 2026-08-06 13:23:

Onbekende Peppol-foutcode (nog niet in pep_errors.json).

Factuurnummer: 260700190

Ruwe boodschap zoals ontvangen van de API:
Task completed