### PR TITLE
✨ Feature: Onbekende Peppol-foutcode (nog niet in pep_errors.

### DIFF
--- a/features/feature-0cbcef5e.md
+++ b/features/feature-0cbcef5e.md
@@ -1,0 +1,12 @@
+**Type:** Feature-aanvraag
+**Reporter:** bart
+**Datum:** 2026-08-06 14:19
+
+**Beschrijving:**
+
+Onbekende Peppol-foutcode (nog niet in pep_errors.json).
+
+Factuurnummer: 260700192
+
+Ruwe boodschap zoals ontvangen van de API:
+Task completed


### PR DESCRIPTION
Automatisch gegenereerde feature-aanvraag door bart op 2026-08-06 14:19:

Onbekende Peppol-foutcode (nog niet in pep_errors.json).

Factuurnummer: 260700192

Ruwe boodschap zoals ontvangen van de API:
Task completed