### PR TITLE
✨ Feature: Onbekende Peppol-foutcode (nog niet in pep_errors.

### DIFF
--- a/features/feature-d739ad91.md
+++ b/features/feature-d739ad91.md
@@ -1,0 +1,12 @@
+**Type:** Feature-aanvraag
+**Reporter:** test
+**Datum:** 2026-08-06 14:58
+
+**Beschrijving:**
+
+Onbekende Peppol-foutcode (nog niet in pep_errors.json).
+
+Factuurnummer: 260700192
+
+Ruwe boodschap zoals ontvangen van de API:
+Task completed


### PR DESCRIPTION
Automatisch gegenereerde feature-aanvraag door test op 2026-08-06 14:58:

Onbekende Peppol-foutcode (nog niet in pep_errors.json).

Factuurnummer: 260700192

Ruwe boodschap zoals ontvangen van de API:
Task completed